### PR TITLE
Renamed the Converter to ApacheHttpUriConverter as its more explicit.

### DIFF
--- a/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapter.java
+++ b/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapter.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 public class ApacheHttpTraversonClientAdapter implements TraversonClient {
 
     private final CloseableHttpClient adapterClient;
-    private final Converter converter;
+    private final ApacheHttpUriConverter apacheHttpUriConverter;
 
 
     public ApacheHttpTraversonClientAdapter() {
@@ -29,12 +29,12 @@ public class ApacheHttpTraversonClientAdapter implements TraversonClient {
 
     public ApacheHttpTraversonClientAdapter(CloseableHttpClient client) {
         this.adapterClient = client;
-        this.converter = new Converter(new BodyFactory(), new TemplateUriUtils(), ResourceConversionService.getInstance());
+        this.apacheHttpUriConverter = new ApacheHttpUriConverter(new BodyFactory(), new TemplateUriUtils(), ResourceConversionService.getInstance());
     }
 
     @Override
     public <T> Response<T> execute(Request request, Class<T> returnType) {
-        HttpUriRequest httpUriRequest = converter.toRequest(request);
+        HttpUriRequest httpUriRequest = apacheHttpUriConverter.toRequest(request);
 
         HttpClientContext clientContext = HttpClientContext.create();
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
@@ -52,7 +52,7 @@ public class ApacheHttpTraversonClientAdapter implements TraversonClient {
         CloseableHttpResponse httpResponse = null;
         try {
             httpResponse = adapterClient.execute(httpUriRequest, clientContext);
-            return converter.toResponse(httpResponse, httpUriRequest.getURI(), returnType);
+            return apacheHttpUriConverter.toResponse(httpResponse, httpUriRequest.getURI(), returnType);
         } catch (IOException e) {
             throw new HttpException("Error with httpClient", e);
         } finally {

--- a/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpUriConverter.java
+++ b/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpUriConverter.java
@@ -19,7 +19,7 @@ public class ApacheHttpUriConverter {
     private final TemplateUriUtils templateUriUtils;
     private final ResourceConversionService conversionService;
 
-    ApacheHttpUriConverter(BodyFactory bodyFactory, TemplateUriUtils templateUriUtils, ResourceConversionService conversionService) {
+    public ApacheHttpUriConverter(BodyFactory bodyFactory, TemplateUriUtils templateUriUtils, ResourceConversionService conversionService) {
         this.bodyFactory = bodyFactory;
         this.templateUriUtils = templateUriUtils;
         this.conversionService = conversionService;

--- a/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpUriConverter.java
+++ b/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpUriConverter.java
@@ -13,13 +13,13 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
-class Converter {
+public class ApacheHttpUriConverter {
 
     private final BodyFactory bodyFactory;
     private final TemplateUriUtils templateUriUtils;
     private final ResourceConversionService conversionService;
 
-    Converter(BodyFactory bodyFactory, TemplateUriUtils templateUriUtils, ResourceConversionService conversionService) {
+    ApacheHttpUriConverter(BodyFactory bodyFactory, TemplateUriUtils templateUriUtils, ResourceConversionService conversionService) {
         this.bodyFactory = bodyFactory;
         this.templateUriUtils = templateUriUtils;
         this.conversionService = conversionService;

--- a/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpUriConverter.java
+++ b/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpUriConverter.java
@@ -25,7 +25,7 @@ public class ApacheHttpUriConverter {
         this.conversionService = conversionService;
     }
 
-    HttpUriRequest toRequest(Request request) {
+    public HttpUriRequest toRequest(Request request) {
         Map<String, List<String>> templateParams = request.getTemplateParams();
         String uri = templateUriUtils.expandTemplateUri(request.getUrl(), templateParams);
 
@@ -45,7 +45,7 @@ public class ApacheHttpUriConverter {
     }
 
 
-    <T> Response<T> toResponse(CloseableHttpResponse httpResponse, URI requestUri, Class<T> returnType) throws IOException {
+    public <T> Response<T> toResponse(CloseableHttpResponse httpResponse, URI requestUri, Class<T> returnType) throws IOException {
         Response<T> response = new Response<T>();
         response.setUri(requestUri);
         response.setStatusCode(httpResponse.getStatusLine().getStatusCode());

--- a/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/TemplateUriUtils.java
+++ b/traverson4j-hc4/src/main/java/uk/co/autotrader/traverson/http/TemplateUriUtils.java
@@ -5,7 +5,7 @@ import com.damnhandy.uri.template.UriTemplate;
 import java.util.List;
 import java.util.Map;
 
-class TemplateUriUtils {
+public class TemplateUriUtils {
 
     String expandTemplateUri(String templateUri, Map<String, List<String>> templateParams) {
         UriTemplate uriTemplate = UriTemplate.fromTemplate(templateUri);

--- a/traverson4j-hc4/src/test/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapterTest.java
+++ b/traverson4j-hc4/src/test/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapterTest.java
@@ -35,7 +35,7 @@ public class ApacheHttpTraversonClientAdapterTest {
     @Mock
     private CloseableHttpClient httpClient;
     @Mock
-    private Converter converter;
+    private ApacheHttpUriConverter apacheHttpUriConverter;
     @Mock
     private HttpUriRequest httpRequest;
     @Mock
@@ -51,12 +51,12 @@ public class ApacheHttpTraversonClientAdapterTest {
     public void setUp() throws Exception {
         URI uri = new URI("http://localhost");
         clientAdapter = new ApacheHttpTraversonClientAdapter(httpClient);
-        FieldUtils.writeField(clientAdapter, "converter", converter, true);
+        FieldUtils.writeField(clientAdapter, "apacheHttpUriConverter", apacheHttpUriConverter, true);
         request = new Request();
         expectedResponse = new Response<JSONObject>();
         when(httpRequest.getURI()).thenReturn(uri);
-        when(converter.toRequest(request)).thenReturn(httpRequest);
-        when(converter.toResponse(httpResponse, uri, JSONObject.class)).thenReturn(expectedResponse);
+        when(apacheHttpUriConverter.toRequest(request)).thenReturn(httpRequest);
+        when(apacheHttpUriConverter.toResponse(httpResponse, uri, JSONObject.class)).thenReturn(expectedResponse);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ApacheHttpTraversonClientAdapterTest {
     @Test
     public void execute_GivenIOExceptionIsThrown_WrapsInTraversonException() throws Exception {
         when(httpClient.execute(eq(httpRequest), any(HttpClientContext.class))).thenReturn(httpResponse);
-        when(converter.toResponse(httpResponse, httpRequest.getURI(), JSONObject.class)).thenThrow(new IOException());
+        when(apacheHttpUriConverter.toResponse(httpResponse, httpRequest.getURI(), JSONObject.class)).thenThrow(new IOException());
         expectedException.expect(HttpException.class);
 
         clientAdapter.execute(request, JSONObject.class);

--- a/traverson4j-hc4/src/test/java/uk/co/autotrader/traverson/http/ApacheHttpUriConverterTest.java
+++ b/traverson4j-hc4/src/test/java/uk/co/autotrader/traverson/http/ApacheHttpUriConverterTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ConverterTest {
-    private Converter converter;
+public class ApacheHttpUriConverterTest {
+    private ApacheHttpUriConverter apacheHttpUriConverter;
     @Mock
     private BodyFactory bodyFactory;
     @Mock
@@ -40,7 +40,7 @@ public class ConverterTest {
 
     @Before
     public void setUp() throws Exception {
-        converter = new Converter(bodyFactory, uriUtils, conversionService);
+        apacheHttpUriConverter = new ApacheHttpUriConverter(bodyFactory, uriUtils, conversionService);
     }
 
     @Test
@@ -48,7 +48,7 @@ public class ConverterTest {
         Request request = new Request();
         request.setMethod(Method.PATCH);
 
-        HttpUriRequest uriRequest = converter.toRequest(request);
+        HttpUriRequest uriRequest = apacheHttpUriConverter.toRequest(request);
 
         assertThat(uriRequest.getMethod()).isEqualTo("PATCH");
     }
@@ -61,7 +61,7 @@ public class ConverterTest {
         request.setUrl(url);
         when(uriUtils.expandTemplateUri(url, request.getTemplateParams())).thenReturn(url);
 
-        HttpUriRequest uriRequest = converter.toRequest(request);
+        HttpUriRequest uriRequest = apacheHttpUriConverter.toRequest(request);
 
         assertThat(uriRequest.getURI().toASCIIString()).isEqualTo(url);
     }
@@ -76,7 +76,7 @@ public class ConverterTest {
         request.addQueryParam("key2", "value2");
         when(uriUtils.expandTemplateUri(url, request.getTemplateParams())).thenReturn(url);
 
-        HttpUriRequest uriRequest = converter.toRequest(request);
+        HttpUriRequest uriRequest = apacheHttpUriConverter.toRequest(request);
 
         assertThat(uriRequest.getURI().toASCIIString()).isEqualTo("http://localhost:8080?key1=value1&key2=value2");
     }
@@ -91,7 +91,7 @@ public class ConverterTest {
         request.addTemplateParam("tmp2", "123");
         when(uriUtils.expandTemplateUri(url, request.getTemplateParams())).thenReturn("http://localhost:8080/abc/stuff?tmp2=123");
 
-        HttpUriRequest uriRequest = converter.toRequest(request);
+        HttpUriRequest uriRequest = apacheHttpUriConverter.toRequest(request);
 
         assertThat(uriRequest.getURI().toASCIIString()).isEqualTo("http://localhost:8080/abc/stuff?tmp2=123");
         verify(uriUtils).expandTemplateUri(url, request.getTemplateParams());
@@ -104,7 +104,7 @@ public class ConverterTest {
         request.addHeader("header1", "value1");
         request.addHeader("header2", "value2");
 
-        HttpUriRequest uriRequest = converter.toRequest(request);
+        HttpUriRequest uriRequest = apacheHttpUriConverter.toRequest(request);
 
         assertThat(uriRequest.getFirstHeader("header1").getValue()).isEqualTo("value1");
         assertThat(uriRequest.getFirstHeader("header2").getValue()).isEqualTo("value2");
@@ -116,7 +116,7 @@ public class ConverterTest {
         request.setMethod(Method.GET);
         request.setAcceptMimeType("application/json");
 
-        HttpUriRequest uriRequest = converter.toRequest(request);
+        HttpUriRequest uriRequest = apacheHttpUriConverter.toRequest(request);
 
         assertThat(uriRequest.getFirstHeader("Accept").getValue()).isEqualTo("application/json");
     }
@@ -129,7 +129,7 @@ public class ConverterTest {
         request.setBody(body);
         when(bodyFactory.toEntity(body)).thenReturn(httpEntity);
 
-        HttpEntityEnclosingRequestBase uriRequest = (HttpEntityEnclosingRequestBase) converter.toRequest(request);
+        HttpEntityEnclosingRequestBase uriRequest = (HttpEntityEnclosingRequestBase) apacheHttpUriConverter.toRequest(request);
 
         assertThat(uriRequest.getEntity()).isEqualTo(httpEntity);
     }
@@ -142,7 +142,7 @@ public class ConverterTest {
         when(statusLine.getStatusCode()).thenReturn(200);
         when(httpResponse.getAllHeaders()).thenReturn(new Header[]{new BasicHeader("Location", "http://localhost/new")});
 
-        Response<String> response = converter.toResponse(httpResponse, requestUri, String.class);
+        Response<String> response = apacheHttpUriConverter.toResponse(httpResponse, requestUri, String.class);
 
         assertThat(response).isNotNull();
         assertThat(response.getUri()).isEqualTo(requestUri);
@@ -164,7 +164,7 @@ public class ConverterTest {
         when(statusLine.getStatusCode()).thenReturn(202);
         when(httpResponse.getAllHeaders()).thenReturn(new Header[0]);
 
-        Response<String> response = converter.toResponse(httpResponse, requestUri, String.class);
+        Response<String> response = apacheHttpUriConverter.toResponse(httpResponse, requestUri, String.class);
 
         assertThat(response.getResource()).isEqualTo(expectedJson);
     }


### PR DESCRIPTION
Adjusted the access levels of the ApacheHttpUriConverter and TemplateUriUtils to be public so this will make it easier for individuals to use them.

Updated all associated Tests.