### PR TITLE
Extended TraversonBuilder to allow pre-emptive authentication, 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,8 @@ subprojects {
                 'com.google.guava:guava:18.0',
                 'org.mockito:mockito-core:1.10.19',
                 'org.assertj:assertj-core:3.11.1',
-                'org.apache.commons:commons-lang3:3.4'
+                'org.apache.commons:commons-lang3:3.4',
+                'com.google.code.findbugs:findbugs-annotations:3.0.1'
     }
 
     jacocoTestCoverageVerification {

--- a/traverson4j-core/src/main/java/uk/co/autotrader/traverson/TraversonBuilder.java
+++ b/traverson4j-core/src/main/java/uk/co/autotrader/traverson/TraversonBuilder.java
@@ -114,7 +114,19 @@ public class TraversonBuilder {
      * @return the current builder inclusive of auth credentials
      */
     public TraversonBuilder withAuth(String username, String password, String hostname) {
-        this.request.addAuthCredential(new AuthCredential(username, password, hostname));
+        return withAuth(username, password, hostname, false);
+    }
+
+    /**
+     * Apply the following basic auth credentials for only http requests on the supplied hostname
+     * @param username the username
+     * @param password the password
+     * @param hostname simple definition of a hostname, e.g. "myservice.autotrader.co.uk"
+     * @param preemptiveAuthentication when true, we preemptively send the username and password to the server instead of reacting to a unauthorized/401 response
+     * @return the current builder inclusive of auth credentials
+     */
+    public TraversonBuilder withAuth(String username, String password, String hostname, boolean preemptiveAuthentication) {
+        this.request.addAuthCredential(new AuthCredential(username, password, hostname, preemptiveAuthentication));
         return this;
     }
 

--- a/traverson4j-core/src/main/java/uk/co/autotrader/traverson/http/AuthCredential.java
+++ b/traverson4j-core/src/main/java/uk/co/autotrader/traverson/http/AuthCredential.java
@@ -2,14 +2,16 @@ package uk.co.autotrader.traverson.http;
 
 public class AuthCredential {
 
-    private String username;
-    private String password;
-    private String hostname;
+    private final String username;
+    private final String password;
+    private final String hostname;
+    private final boolean preemptiveAuthentication;
 
-    public AuthCredential(String username, String password, String hostname) {
+    public AuthCredential(String username, String password, String hostname, boolean preemptiveAuthentication) {
         this.username = username;
         this.password = password;
         this.hostname = hostname;
+        this.preemptiveAuthentication = preemptiveAuthentication;
     }
 
     public String getUsername() {
@@ -24,4 +26,7 @@ public class AuthCredential {
         return hostname;
     }
 
+    public boolean isPreemptiveAuthentication() {
+        return preemptiveAuthentication;
+    }
 }

--- a/traverson4j-core/src/test/java/uk/co/autotrader/traverson/TraversonBuilderTest.java
+++ b/traverson4j-core/src/test/java/uk/co/autotrader/traverson/TraversonBuilderTest.java
@@ -206,6 +206,7 @@ public class TraversonBuilderTest {
         assertThat(credential.getUsername()).isEqualTo("user");
         assertThat(credential.getPassword()).isEqualTo("password");
         assertThat(credential.getHostname()).isNull();
+        assertThat(credential.isPreemptiveAuthentication()).isFalse();
     }
 
     @Test
@@ -218,6 +219,20 @@ public class TraversonBuilderTest {
         assertThat(credential.getUsername()).isEqualTo("user");
         assertThat(credential.getPassword()).isEqualTo("password");
         assertThat(credential.getHostname()).isEqualTo("autotrader.co.uk");
+        assertThat(credential.isPreemptiveAuthentication()).isFalse();
+    }
+
+    @Test
+    public void withAuth_SetsCredentialsIncludingPreemptiveAuthentication() throws Exception {
+        assertThat(builder.withAuth("user", "password", "autotrader.co.uk", true)).isEqualTo(builder);
+        List<AuthCredential> authCredentials = reflectionGetRequest().getAuthCredentials();
+
+        assertThat(authCredentials).hasSize(1);
+        AuthCredential credential = authCredentials.get(0);
+        assertThat(credential.getUsername()).isEqualTo("user");
+        assertThat(credential.getPassword()).isEqualTo("password");
+        assertThat(credential.getHostname()).isEqualTo("autotrader.co.uk");
+        assertThat(credential.isPreemptiveAuthentication()).isTrue();
     }
 
     @Test

--- a/traverson4j-hc4/build.gradle
+++ b/traverson4j-hc4/build.gradle
@@ -2,4 +2,6 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient:4.5.6',
             'org.apache.httpcomponents:httpmime:4.5.6',
             'com.damnhandy:handy-uri-templates:2.1.2'
+
+    testCompile "com.github.tomakehurst:wiremock-jre8:2.27.0"
 }

--- a/traverson4j-hc4/src/test/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapterTest.java
+++ b/traverson4j-hc4/src/test/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapterTest.java
@@ -82,7 +82,7 @@ public class ApacheHttpTraversonClientAdapterTest {
     @Test
     public void execute_GivenRequestWithAuthCredentials() throws Exception {
         when(httpClient.execute(eq(httpRequest), clientContextCaptor.capture())).thenReturn(httpResponse);
-        request.addAuthCredential(new AuthCredential("user", "password", null));
+        request.addAuthCredential(new AuthCredential("user", "password", null, false));
 
         Response<JSONObject> response = clientAdapter.execute(request, JSONObject.class);
 
@@ -97,7 +97,7 @@ public class ApacheHttpTraversonClientAdapterTest {
     @Test
     public void execute_GivenRequestWithScopedAuthCredentials() throws Exception {
         when(httpClient.execute(eq(httpRequest), clientContextCaptor.capture())).thenReturn(httpResponse);
-        request.addAuthCredential(new AuthCredential("user", "password", "myhost.autotrader.co.uk"));
+        request.addAuthCredential(new AuthCredential("user", "password", "myhost.autotrader.co.uk", false));
 
         Response<JSONObject> response = clientAdapter.execute(request, JSONObject.class);
 
@@ -112,9 +112,9 @@ public class ApacheHttpTraversonClientAdapterTest {
     @Test
     public void execute_GivenMultipleAuthCredentials() throws Exception {
         when(httpClient.execute(eq(httpRequest), clientContextCaptor.capture())).thenReturn(httpResponse);
-        request.addAuthCredential(new AuthCredential("user", "password", "myhost.autotrader.co.uk"));
-        request.addAuthCredential(new AuthCredential("user2", "password2", "myhost.autotrader.co.uk"));
-        request.addAuthCredential(new AuthCredential("user3", "password3", null));
+        request.addAuthCredential(new AuthCredential("user", "password", "myhost.autotrader.co.uk", false));
+        request.addAuthCredential(new AuthCredential("user2", "password2", "myhost.autotrader.co.uk", false));
+        request.addAuthCredential(new AuthCredential("user3", "password3", null, false));
 
         Response<JSONObject> response = clientAdapter.execute(request, JSONObject.class);
 

--- a/traverson4j-hc4/src/test/java/uk/co/autotrader/traverson/http/IntegrationTest.java
+++ b/traverson4j-hc4/src/test/java/uk/co/autotrader/traverson/http/IntegrationTest.java
@@ -1,0 +1,54 @@
+package uk.co.autotrader.traverson.http;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.co.autotrader.traverson.Traverson;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IntegrationTest {
+    @Rule
+    @SuppressFBWarnings
+    public WireMockRule wireMockRule = new WireMockRule(8089);
+
+    private Traverson traverson = new Traverson(new ApacheHttpTraversonClientAdapter());
+
+
+    @Test
+    public void basicAuthentication_ReactsToUnauthorizedStatusAndAuthenticateHeader() {
+        stubFor(get("/restricted-area")
+                .inScenario("Restricted access").whenScenarioStateIs(STARTED)
+                .willSetStateTo("First request made")
+                .willReturn(unauthorized().withHeader("WWW-Authenticate", "Basic realm=\"User Visible Realm\"")));
+
+        stubFor(get("/restricted-area")
+                .inScenario("Restricted access").whenScenarioStateIs("First request made")
+                .withBasicAuth("MyUsername", "MyPassword")
+                .willReturn(ok()));
+
+        Response<String> response = traverson.from("http://localhost:8089/restricted-area")
+                                            .withAuth("MyUsername", "MyPassword", "http://localhost:8089")
+                                            .get(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        verify(2, getRequestedFor(urlEqualTo("/restricted-area")));
+    }
+
+    @Test
+    public void basicAuthentication_GivenPreemptiveAuthenticationSetToTrue_SendsUsernameAndPasswordWithoutNeedingAnUnauthorizedResponse() {
+        stubFor(get("/restricted-area")
+                .withBasicAuth("MyUsername", "MyPassword")
+                .willReturn(ok()));
+
+        Response<String> response = traverson.from("http://localhost:8089/restricted-area")
+                                            .withAuth("MyUsername", "MyPassword", "http://localhost:8089", true)
+                                            .get(String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        verify(1, getRequestedFor(urlEqualTo("/restricted-area")));
+    }
+}


### PR DESCRIPTION
essentially to reduce traffic between client and server. Pre-emptive authentication is not a recommended practice with web security, as incorrect configuration can result in sending credentials to an unexpected host. Please use with caution.