### PR TITLE
Correcting the scope for the traverson4j-core dependency so it comes …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,12 +144,12 @@ nexusPublishing {
 
 project(':traverson4j-hc5') {
     dependencies {
-        implementation project(':traverson4j-core')
+        api project(':traverson4j-core')
     }
 }
 
 project(':traverson4j-jackson2') {
     dependencies {
-        implementation project(':traverson4j-core')
+        api project(':traverson4j-core')
     }
 }


### PR DESCRIPTION
…bundled at compile time when picking either hc5 or jackson2