### PR TITLE
Allow setting of Accept header in traverson request

### DIFF
--- a/traverson4j-hc5/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpConverters.java
+++ b/traverson4j-hc5/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpConverters.java
@@ -46,7 +46,9 @@ public class ApacheHttpConverters {
 
         request.getHeaders().forEach(requestBuilder::addHeader);
 
-        requestBuilder.addHeader("Accept", request.getAcceptMimeType());
+        if (request.getAcceptMimeType() != null) {
+            requestBuilder.addHeader("Accept", request.getAcceptMimeType());
+        }
 
         Body body = request.getBody();
         if (body != null) {

--- a/traverson4j-hc5/src/test/java/uk/co/autotrader/traverson/http/IntegrationTest.java
+++ b/traverson4j-hc5/src/test/java/uk/co/autotrader/traverson/http/IntegrationTest.java
@@ -45,6 +45,20 @@ public class IntegrationTest {
         wireMockServer.stubFor(get(urlEqualTo("/"))
                 .willReturn(WireMock.status(200).withBody(htmlBody)));
 
+        Response<String> response = traverson.from("http://localhost:8089")
+                .withHeader("Accept", "content-type")
+                .get(String.class);
+
+        assertThat(response.getResource()).isEqualTo(htmlBody);
+        wireMockServer.verify(getRequestedFor(urlPathEqualTo("/"))
+                .withHeader("Accept", equalTo("content-type")));
+    }
+
+    @Test
+    public void acceptHeaderCanBeSet() throws IOException {
+        String htmlBody = "<html></html>";
+        wireMockServer.stubFor(get(urlEqualTo("/")).willReturn(WireMock.status(200).withBody(htmlBody)));
+
         Response<InputStream> response = traverson.from("http://localhost:8089").get(InputStream.class);
         try (InputStream inputStream = response.getResource()) {
             assertThat(inputStream.readAllBytes()).isEqualTo(htmlBody.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
only set Accept as acceptMimeType field in request object
add test for setting explicit accept type in traverson request