### PR TITLE
Ignore template params with empty values

### DIFF
--- a/traverson4j-hc5/src/main/java/uk/co/autotrader/traverson/http/TemplateUriUtils.java
+++ b/traverson4j-hc5/src/main/java/uk/co/autotrader/traverson/http/TemplateUriUtils.java
@@ -10,7 +10,9 @@ public class TemplateUriUtils {
     String expandTemplateUri(String templateUri, Map<String, List<String>> templateParams) {
         UriTemplate uriTemplate = UriTemplate.fromTemplate(templateUri);
         for (Map.Entry<String, List<String>> templateParam : templateParams.entrySet()) {
-            uriTemplate.set(templateParam.getKey(), templateParam.getValue());
+            if (!templateParam.getValue().isEmpty()) {
+                uriTemplate.set(templateParam.getKey(), templateParam.getValue());
+            }
         }
         return uriTemplate.expand();
     }

--- a/traverson4j-hc5/src/test/java/uk/co/autotrader/traverson/http/TemplateUriUtilsTest.java
+++ b/traverson4j-hc5/src/test/java/uk/co/autotrader/traverson/http/TemplateUriUtilsTest.java
@@ -5,10 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,4 +64,15 @@ class TemplateUriUtilsTest {
         assertThat(uri).isEqualTo("http://example.autotrader.co.uk/dealers?dealerId=1234&dealerId=4567&dealerId=78910");
     }
 
+    @Test
+    void expandTemplateUri_GivenTemplateUriAndEmptyValueForTemplateParam_ExpandsTemplate() {
+        String input = "http://example.autotrader.co.uk/dealers{?dealerId,param}";
+        Map<String, List<String>> templateParams = new HashMap<>();
+        templateParams.put("dealerId", Arrays.asList("1234"));
+        templateParams.put("param", new ArrayList<>());
+
+        String uri = templateUriUtils.expandTemplateUri(input, templateParams);
+
+        assertThat(uri).isEqualTo("http://example.autotrader.co.uk/dealers?dealerId=1234");
+    }
 }


### PR DESCRIPTION
Currently if you were to call `TemplateUriUtils.expandTemplateUri(String templateUri, Map<String, List<String>> templateParams)` and the value of one of the entries in the `templateParams` map is empty then you will get an exception. This is an issue with the `damnhandy/handy-uri-templates` dependency that we are using. I'm planning to raise an issue/PR in the `damnhandy` library but in the meantime i've added a temporary fix that just filters out entries in `templateParams` with an empty value. 