### PR TITLE
breaking change: ability to inspect the response object for headers a…

### DIFF
--- a/traverson4j-core/src/main/java/uk/co/autotrader/traverson/http/Response.java
+++ b/traverson4j-core/src/main/java/uk/co/autotrader/traverson/http/Response.java
@@ -3,11 +3,14 @@ package uk.co.autotrader.traverson.http;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class Response<T> {
     private int statusCode;
     private URI uri;
     private T resource;
+    private boolean resourceConsumed = false;
+    private Supplier<T> resourceF = () -> null;
     private Map<String, String> responseHeaders = new HashMap<String, String>();
 
     public int getStatusCode() {
@@ -27,11 +30,20 @@ public class Response<T> {
     }
 
     public T getResource() {
+        if (!resourceConsumed) {
+            resource = resourceF.get();
+            resourceConsumed = true;
+        }
         return resource;
     }
 
     public void setResource(T resource) {
-        this.resource = resource;
+        setResource(() -> resource);
+    }
+
+    public void setResource(Supplier<T> resourceF) {
+        this.resourceConsumed = false;
+        this.resourceF = resourceF;
     }
 
     public Map<String, String> getResponseHeaders() {

--- a/traverson4j-core/src/test/java/uk/co/autotrader/traverson/http/ResponseTest.java
+++ b/traverson4j-core/src/test/java/uk/co/autotrader/traverson/http/ResponseTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,6 +34,21 @@ class ResponseTest {
         assertThat(response.getStatusCode()).isEqualTo(200);
         assertThat(response.getUri()).isEqualTo(uri);
         assertThat(response.getResponseHeaders()).isEqualTo(headers);
+    }
+
+    @Test
+    void getResource_CachesResourceOnceLoaded() {
+        Response<String> response = new Response<>();
+        response.setResource(() -> UUID.randomUUID().toString());
+
+        assertThat(response.getResource()).isEqualTo(response.getResource());
+    }
+
+    @Test
+    void getResource_GivenNoResourceSet_ReturnsNull() {
+        Response<String> response = new Response<>();
+
+        assertThat(response.getResource()).isNull();
     }
 
     @ParameterizedTest(name = "given{0}StatusCode_isSuccessfulReturnsFalse")

--- a/traverson4j-hc5/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpConverters.java
+++ b/traverson4j-hc5/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpConverters.java
@@ -1,6 +1,7 @@
 package uk.co.autotrader.traverson.http;
 
 
+import com.alibaba.fastjson2.util.IOUtils;
 import org.apache.hc.client5.http.auth.AuthCache;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -24,6 +25,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class ApacheHttpConverters {
     private static final AuthScope AUTH_SCOPE_MATCHING_ANYTHING = new AuthScope(null, null, -1, null, null);
@@ -70,7 +72,16 @@ public class ApacheHttpConverters {
         HttpEntity httpEntity = httpResponse.getEntity();
         if (httpEntity != null) {
             InputStream content = httpEntity.getContent();
-            response.setResource(conversionService.convert(content, returnType));
+            Supplier<T> getResource = () -> {
+                try {
+                    return conversionService.convert(content, returnType);
+                } finally {
+                    if (!returnType.isAssignableFrom(InputStream.class)) {
+                        IOUtils.close(httpResponse);
+                    }
+                }
+            };
+            response.setResource(getResource);
         }
         return response;
     }

--- a/traverson4j-hc5/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapter.java
+++ b/traverson4j-hc5/src/main/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapter.java
@@ -11,7 +11,6 @@ import uk.co.autotrader.traverson.exception.HttpException;
 import uk.co.autotrader.traverson.http.entity.BodyFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 
 public class ApacheHttpTraversonClientAdapter implements TraversonClient {
@@ -34,20 +33,15 @@ public class ApacheHttpTraversonClientAdapter implements TraversonClient {
         ClassicHttpRequest httpRequest = apacheHttpUriConverter.toRequest(request);
         HttpClientContext clientContext = apacheHttpUriConverter.toHttpClientContext(request);
         CloseableHttpResponse httpResponse = null;
-        boolean shouldCloseStream = !returnType.isAssignableFrom(InputStream.class);
         try {
             httpResponse = adapterClient.execute(httpRequest, clientContext);
             return apacheHttpUriConverter.toResponse(httpResponse, returnType, httpRequest.getUri());
         } catch (RuntimeException runtimeException) {
-            shouldCloseStream = true;
+            IOUtils.close(httpResponse);
             throw runtimeException;
         } catch (IOException | URISyntaxException e) {
-            shouldCloseStream = true;
+            IOUtils.close(httpResponse);
             throw new HttpException(e.getMessage(), e);
-        } finally {
-            if (shouldCloseStream) {
-                IOUtils.close(httpResponse);
-            }
         }
     }
 }

--- a/traverson4j-hc5/src/test/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapterTest.java
+++ b/traverson4j-hc5/src/test/java/uk/co/autotrader/traverson/http/ApacheHttpTraversonClientAdapterTest.java
@@ -57,7 +57,7 @@ class ApacheHttpTraversonClientAdapterTest {
         Response<JSONObject> response = clientAdapter.execute(request, JSONObject.class);
 
         assertThat(response).isEqualTo(expectedResponse);
-        verify(httpResponse).close();
+        verify(httpResponse, never()).close();
     }
 
     @Test

--- a/traverson4j-hc5/src/test/java/uk/co/autotrader/traverson/http/IntegrationTest.java
+++ b/traverson4j-hc5/src/test/java/uk/co/autotrader/traverson/http/IntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.co.autotrader.traverson.Traverson;
+import uk.co.autotrader.traverson.exception.ConversionException;
 import uk.co.autotrader.traverson.exception.HttpException;
 
 import java.io.ByteArrayInputStream;
@@ -57,6 +58,22 @@ public class IntegrationTest {
                 .get(String.class);
 
         assertThat(response.getResource()).isEqualTo(htmlBody);
+        wireMockServer.verify(getRequestedFor(urlPathEqualTo("/"))
+                .withHeader("Accept", equalTo("content-type")));
+    }
+
+    @Test
+    void getResource_GivenResourceNotOfExpectedType_AllowsYouToGetStatusCodeFirst() throws IOException {
+        String htmlBody = "<html></html>";
+        wireMockServer.stubFor(get(urlEqualTo("/"))
+                .willReturn(WireMock.status(429).withBody(htmlBody)));
+
+        Response<JSONObject> response = traverson.from("http://localhost:8089")
+                .withHeader("Accept", "content-type")
+                .get(JSONObject.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(429);
+        assertThatThrownBy(response::getResource).isInstanceOf(ConversionException.class);
         wireMockServer.verify(getRequestedFor(urlPathEqualTo("/"))
                 .withHeader("Accept", equalTo("content-type")));
     }


### PR DESCRIPTION
…nd status code before getting the resource.

its quite common that the error resource cannot be parsed by the requested type, which is more annoying when you can't inspect the status code first, to know what situation you're in